### PR TITLE
Crosshair fixes/tweaks

### DIFF
--- a/DECORATE/WEAPONS/Slot1/Saw.txt
+++ b/DECORATE/WEAPONS/Slot1/Saw.txt
@@ -1023,7 +1023,7 @@ states
 	    CSR4 A 0 A_JumpIfInventory("PowerBloodOnVisor",1,4)
 		CSG4 A 0 A_JumpIfInventory("PowerGreenBloodOnVisor",1,3)
 		CSB4 A 0 A_JumpIfInventory("PowerBlueBloodOnVisor",1,2)
-		CSA4 A 0
+		CSA4 A 0 A_SetCrosshair(0)
 	   "####" B 1
 	   "####" X 0 A_PlaySound("foley/GLUpwardsToClose",10,0.7)
 	   "####" CDEF 1
@@ -1036,6 +1036,7 @@ states
 		"####" GH 1//CD 1
 		TNT1 A 0 A_TakeInventory("StartDualWield", 1)
 		//CSA1 FG 1
+		TNT1 A 0 A_SetCrosshair(41)
 	    AXEG A 0 A_PlaySound("weapons/gswing", 1)
 		//AXEG A 0 A_JumpIfInventory("PowerStrength", 1, "StrongThrow")
 		AXEG A 0 A_FireCustomMissile("ThrowedChainsaw", 0, 0, 0, 0)

--- a/DECORATE/WEAPONS/Slot8/HellishMissile.txt
+++ b/DECORATE/WEAPONS/Slot8/HellishMissile.txt
@@ -348,6 +348,7 @@ ACTOR HellishMissileLauncher : BrutalWeapon
 		Wait
 	Select:
 		TNT1 A 0
+		NULL A 0{if(GetCVAR("bd_SmartCrosshairs") == 1){A_SetCrosshair(GetCVAR("HMLCrosshair"));}else{A_SetCrosshair(0);}}
 		Goto SelectFirstPersonLegs
 		SelectContinue: RVCG A 0 A_GiveInventory("IsPlayingDoxMod",1) 
 		TNT1 A 1


### PR DESCRIPTION
- Fixed Hellish Missile Launcher ignoring its smart crosshair setting
- Made the crosshair appear when preparing to throw the Chainsaw, like it does with the Axe