### PR TITLE
fix crash when toggling laser mode in revenant form

### DIFF
--- a/ZScript/Items/DemonRunes.txt
+++ b/ZScript/Items/DemonRunes.txt
@@ -984,7 +984,7 @@ Spawn("GuidedLaser",targetpos);
 	A_StartSound("skeleton/sight",14);
 	A_spawnitemex("DeadMarineArtifact");
 			{
-			If(getCVAR("bd_HellishLaserRockets")==true)
+			If(Countinv("LaserRocket2Selected")==1)
 			{
 			A_StartSound("RAILR1", 2);
 			A_Overlay(15, "lasermode");
@@ -1000,10 +1000,10 @@ Spawn("GuidedLaser",targetpos);
 				//ThrustTHingZ(0, 35, 0, 1);
 				A_Takeinventory("Swapriflespecial",1);
 				
-				If(getCVAR("bd_HellishLaserRockets")==true)
+				If(Countinv("LaserRocket2Selected")==1)
 				{
 				A_StartSound("BEP");
-				A_SetCVAR("bd_hellishLaserRockets",false);
+				A_TakeInventory("LaserRocket2Selected",1);
 				A_Print("Laser Guided Rockets DeActivated");
 				A_StartSound("RAILRIP", 2);
 				A_ClearOverlays(15,15);
@@ -1014,7 +1014,7 @@ Spawn("GuidedLaser",targetpos);
 				
 				A_StartSound("BEP");
 				A_Print("Laser Guided Rockets Activated");
-				A_SetCVAR("bd_HellishLaserRockets",true);
+				A_GiveInventory("LaserRocket2Selected",1);
 				A_StartSound("RAILR1", 2);
 				A_Overlay(15,"LaserMode");
 				}
@@ -1177,7 +1177,7 @@ Spawn("GuidedLaser",targetpos);
 		TNT1 A 0 A_StartSound("skeleton/sight",14);
 	TNT1 A 0 
 			{
-			If(getCVAR("bd_HellishLaserRockets")==true)
+			If(Countinv("LaserRocket2Selected")==1)
 			{
 			A_StartSound("RAILR1", 2);
 			A_Overlay(15,"LaserMode");
@@ -1218,7 +1218,7 @@ Spawn("GuidedLaser",targetpos);
 		RVCG A 0 A_SetPitch(Pitch+0.4, SPF_INTERPOLATE);
         RVCG B 1 BRIGHT 
 		{
-		if (GetCVAR("bd_HellishLaserRockets")==True) {
+		if(Countinv("LaserRocket2Selected")==1) {
 				A_fireprojectile("revenantseekermissiles4", 0, 1, -15, 20);
 			}
 			Else
@@ -1249,7 +1249,7 @@ Spawn("GuidedLaser",targetpos);
 		RVCG A 0 A_SetPitch(Pitch+0.4, SPF_INTERPOLATE);
 	    RVCG F 1 BRIGHT 
 		{
-		if (GetCVAR("bd_HellishLaserRockets")==True) {
+		if(Countinv("LaserRocket2Selected")==1) {
 				A_fireprojectile("revenantseekermissiles4", 0, 1, 15, 20);
 			}
 			Else
@@ -1288,7 +1288,7 @@ Spawn("GuidedLaser",targetpos);
 		RVCG A 0 A_SetPitch(Pitch+random(-1,1), SPF_INTERPOLATE);
         RVCG B 1 BRIGHT
 		{
-		if (GetCVAR("bd_HellishLaserRockets")==True) {
+		if(Countinv("LaserRocket2Selected")==1) {
 				A_fireprojectile("revenantseekermissiles4", 0, 1, -15, 20);
 			}
 			Else
@@ -1308,7 +1308,7 @@ Spawn("GuidedLaser",targetpos);
 		RVCG A 0 A_SetPitch(Pitch+random(-1,1), SPF_INTERPOLATE);
 		RVCG F 1 BRIGHT
 		{
-		if (GetCVAR("bd_HellishLaserRockets")==True) {
+		if(Countinv("LaserRocket2Selected")==1) {
 				A_fireprojectile("revenantseekermissiles4", 0, 1, 15, 20);
 			}
 			Else
@@ -1327,7 +1327,7 @@ Spawn("GuidedLaser",targetpos);
 		RVCG A 0 A_SetPitch(Pitch+random(-1,1), SPF_INTERPOLATE);
 		RVCG B 1 BRIGHT
 		{
-		if (GetCVAR("bd_HellishLaserRockets")==True) {
+		if(Countinv("LaserRocket2Selected")==1) {
 				A_fireprojectile("revenantseekermissiles4", 0, 1, -15, 20);
 			}
 			Else
@@ -1346,7 +1346,7 @@ Spawn("GuidedLaser",targetpos);
 		RVCG A 0 A_SetPitch(Pitch+random(-1,1), SPF_INTERPOLATE);
 		RVCG F 1 BRIGHT 
 		{
-		if (GetCVAR("bd_HellishLaserRockets")==True) {
+		if(Countinv("LaserRocket2Selected")==1) {
 				A_fireprojectile("revenantseekermissiles4", 0, 1, 15, 20);
 			}
 			Else


### PR DESCRIPTION
the revenant transformation was still using getcvar instead of the new inventory system, which caused the game to crash if you tried to toggle laser mode