### PR TITLE
BFG truncation warning fixed, PlaySound conversion on ZScript, Pistol fix

### DIFF
--- a/DECORATE/WEAPONS/Grenades.txt
+++ b/DECORATE/WEAPONS/Grenades.txt
@@ -75,10 +75,12 @@ ACTOR HandGrenades : BrutalWeapon
 		  else
 		  {
 		    A_PLaySound ("GRNPIN");
-			if(CountInv("NadeType")==3)
+//If this statement is needed for later uncomment this out - JM
+/*			if(CountInv("NadeType")==3)
 		    {
+				A_PLaySound ("GRNPIN");
 			//ChangeAmmoIcon1("GRNDC");
-		    }
+		    }*/
 		    }
 		  }
 		}

--- a/DECORATE/WEAPONS/Slot2/Pistol.txt
+++ b/DECORATE/WEAPONS/Slot2/Pistol.txt
@@ -343,7 +343,9 @@ S1LK EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE 1 { //39 total
 		TNT1 AAAAAAAAAAAAAAA 0 A_Raise
 	    PIST F 0 A_JumpIfInventory("GoFatality", 1, "Steady")
 		PIST F 0 A_PlaySound("foley/PistolDualWieldDeselect")
-        P2SA FGHI 1 //A_WeaponReady(WRF_NOFIRE)
+		S2SA F 0 A_JumpIFInventory("IsSilenced",1,2)
+		P2SA F 0
+        "####" FGHI 1 //A_WeaponReady(WRF_NOFIRE)
 		PIST F 0 A_Takeinventory("StartDualWield",1)
 		TNT1 A 0 A_TakeInventory ("SwitchingDualModes", 1)
 		Goto Ready

--- a/ZScript/GORE.txt
+++ b/ZScript/GORE.txt
@@ -224,7 +224,7 @@ class NashGoreRealGibs : RealGibs
 			
 			
 				A_SpawnItemEx("NashGoreSquishyGibs", flags: SXF_TRANSFERTRANSLATION);
-				A_PlaySound("misc/gibbed");
+				A_StartSound("misc/gibbed");
 			
 
 			//Destroy();

--- a/ZScript/PlayerPawn.ZMV
+++ b/ZScript/PlayerPawn.ZMV
@@ -673,7 +673,7 @@ class Brutal_PlayerBase : PlayerPawn
 			player.SetPSprite(PSP_WEAPON,player.ReadyWeapon.FindState("FinishClimb"));
 			
 			A_StopSound(CHAN_WEAPON);
-			A_Playsound("ledgeclimb");
+			A_StartSound("ledgeclimb");
 			LedgeAngle = Angle;
 			LedgeCheck = False;
 			LedgeGrabbed = True;
@@ -711,7 +711,7 @@ class Brutal_PlayerBase : PlayerPawn
 			if(LedgeTime >= 35) { return; }
 			LedgeGrabbed = LedgeTime = LedgeHeight = LedgeHeightMin = LedgeHeightMax = FrameTime = 0;
 			Vel = Vel.Length() ? (5.f * AngleToVector(LedgeAngle), -3) : (0, 0, 0); //push player forward and downward
-			A_PlaySound("*land", CHAN_BODY);
+			A_StartSound("*land", CHAN_BODY);
 		}
 		else
 		{
@@ -856,11 +856,11 @@ Class Hook : Actor
 			monster.a_pain();
 			brutal_playerbase(Target).GrappledMonster = Monster;
 			SetMonsterSpeed(False);
-			A_PlaySound("HookMeat", 7);
+			A_StartSound("HookMeat", 7);
 		}
 		else
 		{
-			A_PlaySound("HookWall", 7);
+			A_StartSound("HookWall", 7);
 		}
 	}
 	

--- a/ZScript/Weapons/Slot6/Railgun.txt
+++ b/ZScript/Weapons/Slot6/Railgun.txt
@@ -179,10 +179,10 @@ CLASS Railgun : Brutalweapon
 			RAIL JKLMNYYOO 1 A_WeaponReadyDX();
 			TNT1 A 0 A_overlay(-5,"pumpinghandlol2");
 			RAIL OOOO 1 A_WeaponReadyDX();
-			TNT1 A 0 A_PlaySound("RAILMAG2", 5);
+			TNT1 A 0 A_StartSound("RAILMAG2", 5);
 			RAIL PR 1 A_WeaponReadyDX();
 			RAIL TWWVUUUUUUUUU/*UUUUUUUUUU*/ 1 A_WeaponReadyDX();
-			TNT1 A 0 A_PlaySound("RAILINSR", 5);
+			TNT1 A 0 A_StartSound("RAILINSR", 5);
 			RAIL UUUUUTTSRQP 1 A_WeaponReadyDX();
 			TNT1 A 0 A_overlay(-5,"pumpinghandlol2reverse");
 			RAIL OOOOONMLKJ 1 A_WeaponReadyDX();
@@ -213,7 +213,7 @@ CLASS Railgun : Brutalweapon
 			RAIL JKLMNYYOO 1;
 			TNT1 A 0 A_overlay(-5,"pumpinghandlol2");
 			RAIL OOOO 1;
-			TNT1 A 0 A_PlaySound("RAILMAG2", 5);
+			TNT1 A 0 A_StartSound("RAILMAG2", 5);
 			RAIL PR 1;
 			TNT1 A 0 
 			{
@@ -249,7 +249,7 @@ CLASS Railgun : Brutalweapon
 		FinishPump:
 			RAIL WWVV 1;
 		FinishPump2:
-		TNT1 A 0 A_PlaySound("RAILINSR", 5);
+		TNT1 A 0 A_StartSound("RAILINSR", 5);
 			RAIL UUUUUTTSRQP 1;
 			TNT1 A 0 A_overlay(-5,"pumpinghandlol2reverse");
 			RAIL OOOOONMLKJ 1;
@@ -362,7 +362,7 @@ CLASS Railgun : Brutalweapon
 		}
 		RAIZ ABCD 1;
 		RLNG A 0 A_SetCrosshair(41);
-		SMGG A 0 A_PlaySound("ADSIN");
+		SMGG A 0 A_StartSound("ADSIN");
 		RAIZ EF 1;
 	AltFireContinue:
 		
@@ -482,7 +482,7 @@ CLASS Railgun : Brutalweapon
 		TNT1 A 0 A_jumpifinventory("PowerSPeed2",1,"StillAiming");
 			SNIP CCCC 1 BRIGHT A_weaponZoom3();
 			
-			TNT1 A 0 A_PlaySound("RAILMAG2", 5);
+			TNT1 A 0 A_StartSound("RAILMAG2", 5);
 			SNIP CC 1 BRIGHT;
 			TNT1 A 0 
 			{
@@ -506,7 +506,7 @@ CLASS Railgun : Brutalweapon
 			//TNT1 A 0 A_WeaponZoom2();
 			SNIP CCCC 1 BRIGHT A_WeaponZoom3();
 
-		TNT1 A 0 A_PlaySound("RAILINSR", 5);
+		TNT1 A 0 A_StartSound("RAILINSR", 5);
 			SNIP CCCCCCCCCC 1 BRIGHT;
 		TNT1 A 0
 			{
@@ -528,7 +528,7 @@ CLASS Railgun : Brutalweapon
 		RLNG A 0 A_Takeinventory("PowerLightAmpc", 1);
         RLNG A 0 A_ZoomFactor(1.0);
 	   // NULL A 0{if(GetCVAR("bd_SmartCrosshairs") == 1){A_SetCrosshair(GetCVAR("RLCrosshair"));}else{A_SetCrosshair(0);}}
-		SMGG A 0 A_PlaySound("ADSOUT");
+		SMGG A 0 A_StartSound("ADSOUT");
         RAIZ FE 1;
 		NULL A 0{if(GetCVAR("bd_SmartCrosshairs") == 1){A_SetCrosshair(GetCVAR("RailgunCrosshair"));}else{A_SetCrosshair(0);}}
 		RAIZ DCBA 1;
@@ -560,7 +560,7 @@ CLASS Railgun : Brutalweapon
 		RLNG A 0 A_Takeinventory("PowerLightAmpc", 1);
         RLNG A 0 A_ZoomFactor(1.0);
 	   // NULL A 0{if(GetCVAR("bd_SmartCrosshairs") == 1){A_SetCrosshair(GetCVAR("RLCrosshair"));}else{A_SetCrosshair(0);}}
-		SMGG A 0 A_PlaySound("ADSOUT");
+		SMGG A 0 A_StartSound("ADSOUT");
         RAIZ FE 1;
 		NULL A 0{if(GetCVAR("bd_SmartCrosshairs") == 1){A_SetCrosshair(GetCVAR("RailgunCrosshair"));}else{A_SetCrosshair(0);}}
 		RAIZ DCBA 1;	
@@ -572,7 +572,7 @@ CLASS Railgun : Brutalweapon
 		RLNG A 0 A_Takeinventory("PowerLightAmpc", 1);
         RLNG A 0 A_ZoomFactor(1.0);
 	   // NULL A 0{if(GetCVAR("bd_SmartCrosshairs") == 1){A_SetCrosshair(GetCVAR("RLCrosshair"));}else{A_SetCrosshair(0);}}
-		SMGG A 0 A_PlaySound("ADSOUT");
+		SMGG A 0 A_StartSound("ADSOUT");
         RAIZ FE 1;
 		NULL A 0{if(GetCVAR("bd_SmartCrosshairs") == 1){A_SetCrosshair(GetCVAR("RailgunCrosshair"));}else{A_SetCrosshair(0);}}
 		RAIZ DCBA 1;	
@@ -584,7 +584,7 @@ CLASS Railgun : Brutalweapon
 		RLNG A 0 A_Takeinventory("PowerLightAmpc", 1);
         RLNG A 0 A_ZoomFactor(1.0);
 	   // NULL A 0{if(GetCVAR("bd_SmartCrosshairs") == 1){A_SetCrosshair(GetCVAR("RLCrosshair"));}else{A_SetCrosshair(0);}}
-		SMGG A 0 A_PlaySound("ADSOUT");
+		SMGG A 0 A_StartSound("ADSOUT");
         RAIZ FE 1;
 		NULL A 0{if(GetCVAR("bd_SmartCrosshairs") == 1){A_SetCrosshair(GetCVAR("RailgunCrosshair"));}else{A_SetCrosshair(0);}}
 		RAIZ DCBA 1;	
@@ -592,14 +592,14 @@ CLASS Railgun : Brutalweapon
 		
 		
 		Pumpinghandlol:
-		TNT1 A 0 A_PlaySound("foley/ShotgunReloadRaise", 6);
+		TNT1 A 0 A_StartSound("foley/ShotgunReloadRaise", 6);
 			RAIH ABCD 1;
 			STOP;
 		Pumpinghandlol2:
 			RAIH IHFE 1;
 			STOP;
 		Pumpinghandlolreverse:
-		TNT1 A 0 A_PlaySound("foley/ShotgunReloadLower", 6);
+		TNT1 A 0 A_StartSound("foley/ShotgunReloadLower", 6);
 			RAIH DCBA 1;
 			STOP;
 		Pumpinghandlol2reverse:
@@ -706,13 +706,13 @@ CLASS Railgun : Brutalweapon
 			RAIL OOOO 1;
 			RAIL A 0 A_JumpIfInventory("NuRailgunAmmo",1,1);
 			Goto FinishUnload;
-			TNT1 A 0 A_PlaySound("RAILMAG2", 5);
+			TNT1 A 0 A_StartSound("RAILMAG2", 5);
 			RAIL PR 1;
 			RAIL TWWV 1;
 			RAIL A 0 A_Takeinventory("NuRailgunAmmo",1);
 			RAIL A 0 A_Giveinventory("AmmoCell",10);
 			RAIL UUUUUUUUU/*UUUUUUUUUU*/ 1;
-			TNT1 A 0 A_PlaySound("RAILINSR", 5);
+			TNT1 A 0 A_StartSound("RAILINSR", 5);
 			RAIL UUUUUTTSRQP 1;
 			Goto RemoveBullets+19;
 		FinishUnload:

--- a/ZScript/Weapons/Slot7/BFG.txt
+++ b/ZScript/Weapons/Slot7/BFG.txt
@@ -692,7 +692,7 @@ CLASS BFG10K_Ball: SuperBFGBall
 
 
 CLASS BFGTendril : tripmineparticle {
-	int fadeoutpercent;
+	double fadeoutpercent;
 	property fadeoutpercent : fadeoutpercent;
 	Default
 	{

--- a/ZScript/Weapons/Slot7/Unmaker.txt
+++ b/ZScript/Weapons/Slot7/Unmaker.txt
@@ -147,7 +147,7 @@ CLASS Unmaker : BrutalWeapon
 		UNHG A 0;
 		UNHG A 0 A_startSOund("UNMCRAK2", 1);
 		UNHF ABCD 1;
-		UNHG A 0 A_PlaySOund("UNMSTA", 1);
+		UNHG A 0 A_StartSound("UNMSTA", 1);
 		UNHG A 0 A_ZoomFactor(0.90);
 		/*
 	    UNHF EFGHEFGHEFGHEFGHEFGHEFGHEFGHEFGHEFGHEFGH 1 BRIGHT
@@ -232,7 +232,7 @@ LineTrace(angle, 64, 0, TRF_BLOCKUSE, offsetz: 7, data: walluse);
 		TNT1 A 0 A_JumpIfInventory("UnmakerUpgrade",1,"ContinueAltFire1") //fires faster.			
 		ContinueAltFire: //Standard altfire
 		TNT1 A 0 A_TakeInventory("SoulAmmo",1)
-		UNHG A 0 A_PlaySOund("UNMALT",1)
+		UNHG A 0 A_StartSound("UNMALT",1)
 		TNT1 A 0 BRIGHT A_fireprojectile("UnmakerTracer", random(-1,1), 0, 0, -1, 0, frandom(-0.4,0.4))
 		TNT1 A 0 BRIGHT A_fireprojectile("ShotgunParticles", random(-12,12), 0, 0, 0, 0, random(-9,9))
 		TNT1 A 0 BRIGHT A_fireprojectile("ShotgunParticles2", random(-12,12), 0, 0, 0, 0, random(-9,9))
@@ -248,7 +248,7 @@ LineTrace(angle, 64, 0, TRF_BLOCKUSE, offsetz: 7, data: walluse);
 		
 		ContinueAltFire1: //Faster fire
 		TNT1 A 0 A_TakeInventory("SoulAmmo",1)
-		UNHG A 0 A_PlaySOund("UNMALT",1)
+		UNHG A 0 A_StartSound("UNMALT",1)
 		TNT1 A 0 BRIGHT A_fireprojectile("UnmakerTracer", random(-1,1), 0, 0, -1, 0, frandom(-0.4,0.4))
 		TNT1 A 0 BRIGHT A_fireprojectile("ShotgunParticles", random(-12,12), 0, 0, 0, 0, random(-9,9))
 		TNT1 A 0 BRIGHT A_fireprojectile("ShotgunParticles2", random(-12,12), 0, 0, 0, 0, random(-9,9))
@@ -263,7 +263,7 @@ LineTrace(angle, 64, 0, TRF_BLOCKUSE, offsetz: 7, data: walluse);
 		Goto Ready
 		
 		ContinueAltFire2: //2 tracers, even faster
-		UNHG A 0 A_PlaySOund("UNMALT",1)
+		UNHG A 0 A_StartSound("UNMALT",1)
 		TNT1 A 0 A_TakeInventory("SoulAmmo",2)
 		TNT1 A 0 BRIGHT A_fireprojectile("UnmakerTracerStronger", random(-3,-1), 0, 0, -1, 0, frandom(-0.4,0.4))
 		TNT1 A 0 BRIGHT A_fireprojectile("UnmakerTracerStronger", random(3,1), 0, 0, -1, 0, frandom(-0.4,0.4))

--- a/ZScript/Weapons/WeaponBase.txt
+++ b/ZScript/Weapons/WeaponBase.txt
@@ -898,7 +898,7 @@ Actor CurrentActor; //A pointer to whatever actor the iterator is iterating thro
 			{
 			invoker.owner.giveinventory("usedstamina",invoker.weight * 6);
 			}
-			A_Playsound("ledgeclimb",5);
+			A_StartSound("ledgeclimb",5);
 			}
 			"####" ABC 1 {
 				let plr = Brutal_PlayerBase(self);
@@ -1521,13 +1521,13 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
 		TNT1 A 0 A_TakeInventory("SwitchFlashlight", 1);
 		TNT1 A 0 A_JumpIfInventory("FlashlightOn",1,"TurnFlashOff");
 		TNT1 A 0 A_Giveinventory("FlashlightOn",1);
-		TNT1 A 0 A_PlaySound("FLASHON", 5);
+		TNT1 A 0 A_StartSound("FLASHON", 5);
 		
         Goto Flash;
 	TurnFlashOff:
 		TNT1 A 0 A_Takeinventory("FlashlightOn",1);
 		TNT1 A 0 A_Light0();
-		TNT1 A 0 A_PlaySound("FLASHOFF", 5);
+		TNT1 A 0 A_StartSound("FLASHOFF", 5);
         Goto Flash;
 		
 		
@@ -1538,7 +1538,7 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
         TNT1 A 0 A_ZoomFactor(1.0);
 		TNT1 A 0 A_Takeinventory("ADSmode",1);
 		
-		TNT1 A 0 A_PlaySound("KICK",69);
+		TNT1 A 0 A_StartSound("KICK",69);
 		RIBA ACE 1;
 		RIFF A 0 A_FireProjectile("KickAttack", 0, 0, 0, 0);
 		RIBA G 5;
@@ -1682,7 +1682,7 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
 		
 	FirstPersonLegsCrouch:
 		"####" A 0;
-		"####" A 0 A_PlaySound("IronSights", 0); //Sound when player crouches
+		"####" A 0 A_StartSound("IronSights", 0); //Sound when player crouches
 	FirstPersonLegsCrouchContinue:
 		"####" A 0 A_JumpIf(vel.Z != 0, "FirstPersonLegsJump");
 		"####" A 0 A_JumpIf(vel.x > 0.8 || vel.x < -0.8 || vel.y > 0.8 || vel.y < -0.8, "FirstPersonLegsWalk1");
@@ -1942,7 +1942,7 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
 		 Return resolveState(null);
 		}//"####" A 0 A_Overlay(1,"KickingFlash")
 		//TNT1 A 0 A_JumpIfInventory("RifleSelected", 1, "RifleBash")
-		TNT1 A 0 A_PlaySound("KICK",69);
+		TNT1 A 0 A_StartSound("KICK",69);
 	//	TNT1 A 0 SetPlayerProperty(0,1,0);
 		//
 		3ICK A 0 A_JumpIf(GetCVAR("bd_LegStainingOptions")==4,8);//perma gren
@@ -2018,7 +2018,7 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
 		}
 		TNT1 A 0;
 	    TNT1 A 0 A_jumpifinventory("PowerStrength",1,"SuperAirKick");
-		TNT1 A 0 A_PlaySound("KICK",69);
+		TNT1 A 0 A_StartSound("KICK",69);
 		KIK4 AB 1 A_bdpmeleestart(400);
 		//
 		3IK4 A 0 A_JumpIf(GetCVAR("bd_LegStainingOptions")==4,8);//perma gren
@@ -2177,9 +2177,9 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
 		
 	SlideAttack:
 		TNT1 A 0; //SetPlayerProperty(0,1,0);
-		TNT1 A 0 A_PlaySound("KICK",69);
+		TNT1 A 0 A_StartSound("KICK",69);
 		TNT1 A 0 A_Recoil (-6);
-		TNT1 A 0 A_PlaySound("SlideKickStart", 5);
+		TNT1 A 0 A_StartSound("SlideKickStart", 5);
 		NULL A 0
 		{ if(CountInv("IsPlayingDoxMod")==0)
 		  {
@@ -2259,7 +2259,7 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
 		"####" A 0 A_Overlay(-610,"SlideKickRightLegOverlayFinish");
 	    "####" A 0; //A_SetPitch(10)
 		"####" A 0 A_WeaponReady();
-		"####" A 0 A_PlaySound("SlideKickStop", 5);
+		"####" A 0 A_StartSound("SlideKickStop", 5);
 		"####" A 0
 		{ if(CountInv("IsPlayingDoxMod")==0)
 		  {
@@ -2366,19 +2366,19 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
 		
 		FuckYourself2:
 		"####" A 0 ACS_NamedExecute("InsultFuckYourself",0,0);
-        "####" B 0 A_PlaySound("FUCK1", 2);
+        "####" B 0 A_StartSound("FUCK1", 2);
 		Goto FinishTauntnone;
 	FhaccYoself2:
 		"####" A 0 ACS_NamedExecute("InsultFhaccYoself",0,0);
-        "####" B 0 A_PlaySound("FUCK3", 2);
+        "####" B 0 A_StartSound("FUCK3", 2);
 		Goto FinishTauntnone;
 	GoFuckYourself2:
 		"####" A 0 ACS_NamedExecute("InsultGoFuckYourself",0,0);
-        "####" B 0 A_PlaySound("FUCK4", 2);
+        "####" B 0 A_StartSound("FUCK4", 2);
 		Goto FinishTauntnone;
 	GetOffScum2:
 		"####" A 0 ACS_NamedExecute("InsultGetOffScum",0,0);
-        "####" B 0 A_PlaySound("FUCK2", 2);
+        "####" B 0 A_StartSound("FUCK2", 2);
 	FinishTauntNone:
 		TNT1 A 0 A_Takeinventory("Taunting",1);
 		TNT1 A 0 A_jumpifinventory("hasagib",1,"Chooseyourgib");
@@ -2423,7 +2423,7 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
 		//NULL A 0 A_JumpIfInventory("HasThrownPipebomb",1,"DetonateTossedPipebomb")
 		DKPB PQRSTU 1;
 		DKPB FGHI 1;
-		TNT1 A 0 A_PlaySound("DukeThrw");
+		TNT1 A 0 A_StartSound("DukeThrw");
 		NULL A 0 A_GiveInventory("HasThrownPipebomb",1);
         TNT1 A 0 
 		{
@@ -2456,7 +2456,7 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
 	    TNT1 A 2;
 		DETO ABCCDDD 1;
 		TNT1 A 0 A_AlertMonsters(300);
-        DETO G 1 A_PlaySound("BEP");
+        DETO G 1 A_StartSound("BEP");
 	    NULL A 0 A_TakeInventory("HasThrownPipebomb",1);
 	    TNT1 A 0 A_RadiusGive("NowBlowUpPleaseUwU",4096, RGF_ITEMS | RGF_MISSILES | RGF_NOSIGHT ,1,null,"ThrownPipebombs");
 	    TNT1 A 0;
@@ -2512,12 +2512,12 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
 		TNT1 A 0 A_GiveInventory("FiredGrenade", 1);
 		TNT1 A 0 A_Giveinventory("Punching",1);
 		TNT1 A 0 A_Giveinventory("GoSpecial",1);
-		TNT1 A 0 A_PLaySound ("GRNPIN");
+		TNT1 A 0 A_StartSound ("GRNPIN");
 		GRTH JKLMN 1;
 		TNT1 A 2 Offset(0,32);
-		TNT1 A 0 A_PLaySound ("CS16uwu");
+		TNT1 A 0 A_StartSound ("CS16uwu");
 		TNT1 A 0 A_Jump(2,2);
-		TNT1 A 0 A_PLaySound ("GRNTOSS");
+		TNT1 A 0 A_StartSound ("GRNTOSS");
 		TNT1 A 0;
 		TNT1 A 0 A_JumpIfInventory("TossGrenade", 1, "TossGrenadeGently");
 		//TNT1 A 0 A_Recoil(-2)
@@ -2570,12 +2570,12 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
 		TNT1 A 0 A_GiveInventory("FiredGrenade", 1);
 		TNT1 A 0 A_Giveinventory("Punching",1);
 		TNT1 A 0 A_Giveinventory("GoSpecial",1);
-		TNT1 A 0 A_PLaySound ("GRNPIN");
+		TNT1 A 0 A_StartSound ("GRNPIN");
 		4RTH IJKLMN 1;
 		TNT1 A 2 Offset(0,32);
-		TNT1 A 0 A_PLaySound ("CS16uwu");
+		TNT1 A 0 A_StartSound ("CS16uwu");
 		TNT1 A 0 A_Jump(2,2);
-		TNT1 A 0 A_PLaySound ("GRNTOSS");
+		TNT1 A 0 A_StartSound ("GRNTOSS");
 		TNT1 A 0;
 		TNT1 A 0 A_JumpIfInventory("TossGrenade", 1, "TossVoidGrenadeGently");
 		//TNT1 A 0 A_Recoil(-2)
@@ -2625,14 +2625,14 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
 		TNT1 A 0 A_Takeinventory("ADSmode",1);
 		TNT1 A 0 A_JumpIfInventory("IsPlayingAsPurist", 1, "TossGrenadeClassic");
 	    3RTH LMNOE 1;
-		TNT1 A 0 A_PLaySound ("ICEGPRE2");
+		TNT1 A 0 A_StartSound ("ICEGPRE2");
 		3RTH F 3;
 		3RTH GHIJK 1;
 		//TNT1 A 0 A_SetCrosshair(0)
 		TNT1 A 2 Offset(0,32);
-		TNT1 A 0 A_PLaySound ("CS16uwu");
+		TNT1 A 0 A_StartSound ("CS16uwu");
 		TNT1 A 0 A_Jump(2,2);
-		TNT1 A 0 A_PLaySound ("GRNTOSS");
+		TNT1 A 0 A_StartSound ("GRNTOSS");
 		TNT1 A 0;
 		TNT1 A 0 A_JumpIfInventory("TossGrenade", 1, "TossGrenadeFreezeGently");
 		GRTH OP 1;
@@ -3040,7 +3040,7 @@ PI2F K 0 {if (CountInv("Kicking") == 1) { if (CountInv("IsCrouching") == 1) { re
 		THEF N 0;
 		"####" A 0;
 		"####" ABCD 1;
-        "####" A 0 A_PlaySound("skeleton/swing");
+        "####" A 0 A_StartSound("skeleton/swing");
 		"####" A 0 A_Giveinventory("Punching",1);
         "####" E 1 A_fireprojectile("PoorLostSoul", 0, 1, 0, 0);
         "####" GHIJ 1;


### PR DESCRIPTION
- A_PlaySound converted to A_StartSound for ZScript code
- Fixed truncation warning for BFG (int to double). Needs testing just in case it got screwed up.
- Empty if statement on grenades fixed
- Fixed minor issue with dual silenced pistols showing the normal sprites if you switched back to single pistol.

Nothing major, but there are still quite a bit of script warnings, such as the truncation warning on the Unmaker, comparison between signed and unsigned variables, and A_CustomMissile (which I can fix but it uses the CMF_BADPITCH flag which y'all may not want me to do because BadPitch isn't recommended. I heard there is another way but I forgot what it was)