### PR TITLE
Fix Test Map Music

### DIFF
--- a/MAPINFO
+++ b/MAPINFO
@@ -167,7 +167,7 @@ map TEST "UAC Testing Center"
 	sky1 = "SKYEAR6", 0.1
 	cluster = 1
 	//par = 60
-	music = ORB
+	music = ORB.ogg
 }
 
 map PSMAP58 "The Mansion"


### PR DESCRIPTION
In the PR that replaced MP3 music with OGG, the file "ORB" was removed and replaced with "ORB.ogg".

The MAPINFO was not appropriately updated for this change, causing the Test Map to fall back to whichever song was played last.

This should fix that.