### PR TITLE
The player's weapons should not play it's distant sounds by spawning actors

### DIFF
--- a/DECORATE/WEAPONS/Slot3/AssaultShotgun.txt
+++ b/DECORATE/WEAPONS/Slot3/AssaultShotgun.txt
@@ -182,7 +182,7 @@ ACTOR AssaultShotgun : BrutalWeapon
         TNT1 AAAA 0
 		A12G A 0 A_JumpIfInventory("HasUnloaded", 1, "PutMag")
         A12G A 0 { if(Countinv("PlasmaShellSelected")==1) {A_PlaySound("weapons/EnergyASGfire", 1);} else {A_PlaySound("A12FIR", 1);}}
-		RIFF A 0 A_FireCustomMissile("DistantFireSoundShotgun", random(-1,1), 0, 0, -12, 0, random(-1,1))
+		RIFF A 0 A_PlaySound("FARSHT", 1)
 		"----" A 0 { If(GetCVAR("BD_MagGoClicky")==1) { if(CountInv("AssaultShotgunAmmo")<=6) { A_PlaySound("MagClick", 7); }}}
 	//	A12G A 0 A_JumpIfInventory("Zoomed",1,"Fire2")
 		//RIFF A 0 A_FireCustomMissile("GunFireSmoke", 0, 0, 0, -2, 0, 0)

--- a/DECORATE/WEAPONS/Slot3/Shotgun.txt
+++ b/DECORATE/WEAPONS/Slot3/Shotgun.txt
@@ -252,7 +252,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHTN A 0 A_JumpIfInventory("ShotgunWasEmpty", 1, "Pump2")
         SHTN A 0 A_AlertMonstersDX
         SHTN A 0 A_PlaySound("weapons/sg", 1)
-		RIFF A 0 A_FireCustomMissile("DistantFireSoundShotgun", random(-1,1), 0, 0, -12, 0, random(-1,1))
+		RIFF A 0 A_PlaySound("FARSHT", 1)
         SHTN A 0
 		SHTN A 0 A_SpawnItemEx("PlayerMuzzle1",30,5,30)
 		TNT1 A 0 
@@ -517,7 +517,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHTN A 0 A_FireBullets (6, 3, 5, 13, "ShotgunPuff2", FBF_NORANDOM,8192,"decorativetracer",-4)
 		SHTN A 0 A_SetPitch(pitch-10, SPF_INTERPOLATE)
 		SHTN A 0
-		RIFF A 0 A_FireCustomMissile("DistantFireSoundShotgun", random(-1,1), 0, 0, -12, 0, random(-1,1))
+		RIFF A 0 A_PlaySound("FARSHT", 1)
 		//TNT1 AAAAA 0 A_FireCustomMissile("DecorativeTracer", random(-5,5), 0, 0, 0, 0, random(-5,5))
 		SHTN A 0 A_SetPitch(-10.0 + pitch, SPF_INTERPOLATE)
 		SHTN A 0 A_TakeAmmo("ShotgunAmmo",1)
@@ -539,7 +539,7 @@ ACTOR Shot_Gun : BrutalWeapon
 		SHTN A 0 A_FireBullets (0.3, 0.2, 1, 40, "ShotgunPuff2", FBF_NORANDOM)
 		SHTN A 0 A_SetPitch(pitch-10, SPF_INTERPOLATE)
 		SHTN A 0
-		RIFF A 0 A_FireCustomMissile("DistantFireSoundShotgun", random(-1,1), 0, 0, -12, 0, random(-1,1))
+		RIFF A 0 A_PlaySound("FARSHT", 1)
 		//TNT1 AAAAA 0 A_FireCustomMissile("DecorativeTracer", random(-5,5), 0, 0, 0, 0, random(-5,5))
 		SHTN A 0 A_SetPitch(-10.0 + pitch, SPF_INTERPOLATE)
 		SHTN A 0 A_TakeAmmo("ShotgunAmmo",1)

--- a/DECORATE/WEAPONS/Slot4/Rifle.txt
+++ b/DECORATE/WEAPONS/Slot4/Rifle.txt
@@ -247,7 +247,7 @@ ACTOR Rifle : BrutalWeapon
         RIFL C 0 A_CheckIfAmmo("RifleAmmo")
         TNT1 AA 0
 		RIFL C 0 A_AlertMonstersDX
-		RIFF A 0 A_FireCustomMissile("DistantFireSoundRifle", random(-1,1), 0, 0, -12, 0, random(-1,1))
+		RIFF A 0 A_PlaySound("FARRIF", 1)
 		RIFL C 0 A_TakeAmmo("DoubleRifleAmmo",1)
 		RIFL C 0 A_TakeAmmo("RifleAmmo",1)
         RIFL C 0 A_PlaySound("weapons/rifle", 1)
@@ -289,7 +289,7 @@ ACTOR Rifle : BrutalWeapon
 	RIFL C 0 A_CheckIfAmmo("RifleAmmo")
         TNT1 AA 0
 		RIFL C 0 A_AlertMonstersDX
-		RIFF A 0 A_FireCustomMissile("DistantFireSoundRifle", random(-1,1), 0, 0, -12, 0, random(-1,1))
+		RIFF A 0 A_PlaySound("FARRIF", 1)
 		RIFL C 0 A_TakeAmmo("DoubleRifleAmmo",1)
 		RIFL C 0 A_TakeAmmo("RifleAmmo",1)
         RIFL C 0 A_PlaySound("weapons/rifle", 1)

--- a/ZScript/Weapons/Slot3/SuperShotgun.txt
+++ b/ZScript/Weapons/Slot3/SuperShotgun.txt
@@ -341,7 +341,7 @@ CLASS SSG : BrutalWeapon
 		  }
 		}
 		SHTZ A 0;
-		SHTZ A 0 A_PlaySound("FARSSG", 1)
+		SHTZ A 0 A_PlaySound("FARSSG", 1);
 		SHO9 A 0 A_firebullets (0,0,1,40,"shotpuff",FBF_NORANDOM,300);
 		TNT1 A 0 a_alertmonstersDX();
 		

--- a/ZScript/Weapons/Slot3/SuperShotgun.txt
+++ b/ZScript/Weapons/Slot3/SuperShotgun.txt
@@ -341,7 +341,7 @@ CLASS SSG : BrutalWeapon
 		  }
 		}
 		SHTZ A 0;
-		SHTZ A 0 A_fireprojectile("DistantFireSoundSSG", random(-1,1), 0, 0, -12, 0, random(-1,1));
+		SHTZ A 0 A_PlaySound("FARSSG", 1)
 		SHO9 A 0 A_firebullets (0,0,1,40,"shotpuff",FBF_NORANDOM,300);
 		TNT1 A 0 a_alertmonstersDX();
 		


### PR DESCRIPTION
This PR changes how distant sounds are played. Now, the sound follows the player and does not stay where it was when the shot was fired.